### PR TITLE
Add comint-output-filter so output is colorized

### DIFF
--- a/bpr.el
+++ b/bpr.el
@@ -131,6 +131,7 @@ if not, it's called in normal way with one argument - process."
     (setq bpr-last-buffer buffer)
     (set-process-plist process (bpr-create-process-plist))
     (set-process-sentinel process 'bpr-handle-result)
+    (set-process-filter process 'comint-output-filter)
     (bpr-handle-progress process)
     (bpr-config-process-buffer buffer)))
 

--- a/test-bpr.el
+++ b/test-bpr.el
@@ -38,6 +38,7 @@
       (fset 'process-exit-status (lambda (process) nil))
       (fset 'set-process-plist (lambda (process plist) (setq fake-plist plist)))
       (fset 'set-process-sentinel (lambda (process func) nil))
+      (fset 'set-process-filter (lambda (process func) nil))
       (fset 'start-process-shell-command (lambda (name buffer command) fake-process))
 
       (spy-on 'delete-window :and-call-through)


### PR DESCRIPTION
Add comint-output-filter to process so that ouput is colorized in the same way
as async-shell-command.

shell-command has the following:

        ;; Use the comint filter for proper handling of carriage motion
        ;; (see `comint-inhibit-carriage-motion'),.
        (set-process-filter proc 'comint-output-filter)