### PR TITLE
Provide command completion for bpr-spawn

### DIFF
--- a/bpr.el
+++ b/bpr.el
@@ -104,7 +104,8 @@ if not, it's called in normal way with one argument - process."
 ;;;###autoload
 (defun bpr-spawn (cmd)
   "Executes string CMD asynchronously in background."
-  (interactive "sCommand: ")
+  (interactive
+   (list (read-shell-command "Command: ")))
   (let* ((proc-name (bpr-create-process-name cmd))
          (process (get-process proc-name)))
     (if process


### PR DESCRIPTION
Use read-shell-command (provided by by simple.el) for command completion in
brp-spawn prompt.